### PR TITLE
Fix non-existent mixin and make memory read/write takes single address

### DIFF
--- a/Code/MIR-instructions/integer-arithmetic-instructions.lisp
+++ b/Code/MIR-instructions/integer-arithmetic-instructions.lisp
@@ -10,31 +10,31 @@
 
 (defclass signed-less-instruction
     (instruction
-     multiple-successors-mixin
+     two-successors-mixin
      comparison-mixin)
   ())
 
 (defclass signed-not-greater-instruction
     (instruction
-     multiple-successors-mixin
+     two-successors-mixin
      comparison-mixin)
   ())
 
 (defclass unsigned-less-instruction
     (instruction
-     multiple-successors-mixin
+     two-successors-mixin
      comparison-mixin)
   ())
 
 (defclass unsigned-not-greater-instruction
     (instruction
-     multiple-successors-mixin
+     two-successors-mixin
      comparison-mixin)
   ())
 
 (defclass equal-instruction
     (instruction
-     multiple-successors-mixin
+     two-successors-mixin
      comparison-mixin)
   ())
 

--- a/Code/MIR-instructions/integer-arithmetic-instructions.lisp
+++ b/Code/MIR-instructions/integer-arithmetic-instructions.lisp
@@ -37,6 +37,3 @@
      two-successors-mixin
      comparison-mixin)
   ())
-
-(defclass negate-instruction (instruction one-successor-mixin)
-  ())

--- a/Code/MIR-instructions/memory-read-instruction.lisp
+++ b/Code/MIR-instructions/memory-read-instruction.lisp
@@ -1,13 +1,10 @@
 (cl:in-package #:posterior-mir-instructions)
 
-;;; This instruction reads a memory location.  It takes two inputs.
-;;; The first input is the base-address of a location in memory.  The
-;;; second input is an offset to be added to the base address.  It has
-;;; a single output which is set to the contents of the memory
-;;; location at the address specified by the input and the offset
-;;; added together.  The offset must be a literal datum.
+;;; This instruction reads a memory location.  It has a single input
+;;; which is the address of a location in memory.  It has a single
+;;; output which is set to the contents of the memory location
+;;; specified by the input.
 
 (defclass memory-read-instruction (instruction one-successor-mixin)
-  ((%base-address :initarg :base-address :reader base-address)
-   (%offset :initarg :offset :reader offset)
+  ((%address :initarg :address :reader address)
    (%datum :initarg :datum :reader datum)))

--- a/Code/MIR-instructions/memory-write-instruction.lisp
+++ b/Code/MIR-instructions/memory-write-instruction.lisp
@@ -1,14 +1,10 @@
 (cl:in-package #:posterior-mir-instructions)
 
 ;;; This instruction writes an item into a memory location.  It takes
-;;; three inputs.  The first input is the base-address of a location
-;;; in memory.  The second input is an offset to be added to the base
-;;; address.  The third input is the datum to be stored in that
-;;; location.  This instruction adds the input address to the offset
-;;; and stores the input in the resulting address.  The offset must be
-;;; a literal datum.
+;;; two inputs.  The first input is the address of a location in
+;;; memory.  The second input is the datum to be stored in that
+;;; location.
 
-(defclass memset2-instruction (instruction one-successor-mixin)
-  ((%base-address :initarg :base-address :reader base-address)
-   (%offset :initarg :offset :reader offset)
+(defclass memory-write-instruction (instruction one-successor-mixin)
+  ((%address :initarg :address :reader address)
    (%datum :initarg :datum :reader datum)))


### PR DESCRIPTION
This contains two commits that:
1. fix definitions for `integer-arithmetic-instructions`
2. change `memory-read/write-instruction`, remove `offset` and make them accept a single address

2 may be a bit controversial -- my reasoning is that this makes MIR more orthogonal, because address calculation can be represented with add-instruction. Introducing `offset` might make RISC-V code generation slightly simpler, but a reasonably good code generator need to be able to fuse instruction anyways, and I think this is an opportunity to exercise that. Besides, fusion is already needed to make use of RISC-V comparison instructions (I suppose MIR's comparison operator are actually conditional jumps, we need to fuse them with register writes to emit simple integer comparison).

This is my first PR and feel free to point out any issue! Is this the right PR granularity, or I should split into 2, or accumulate more commits?